### PR TITLE
Update to use /api/chat instead of /api/completions to conform to OpenAI calls

### DIFF
--- a/lua/ogpt/api.lua
+++ b/lua/ogpt/api.lua
@@ -54,19 +54,6 @@ function Api.chat_completions(custom_params, cb, should_stop, opts)
           end
         end
 
-        -- local ok, json = pcall(vim.json.decode, chunk)
-        -- if ok and json ~= nil then
-        --   if json.error ~= nil then
-        --     cb(json.error.message, "ERROR")
-        --     return
-        --   end
-        -- end
-        -- for line in chunk:gmatch("[^\n]+") do
-        --   local raw_json = string.gsub(line, "^data: ", "")
-        --   if raw_json == "[DONE]" then
-        --     cb(raw_chunks, "END")
-        --   else
-
         local ok, json = pcall(vim.json.decode, chunk)
         if ok and json ~= nil then
           if json.error ~= nil then
@@ -99,8 +86,10 @@ end
 
 function Api.edits(custom_params, cb)
   local params = vim.tbl_extend("keep", custom_params, Config.options.api_edit_params)
-  params.stream = params.stream or false
-  Api.make_call(Api.CHAT_COMPLETIONS_URL, params, cb)
+  -- params.stream = params.stream or false
+  -- Api.make_call(Api.CHAT_COMPLETIONS_URL, params, cb)
+  params.stream = true
+  Api.chat_completions(params, cb)
 end
 
 function Api.make_call(url, params, cb)

--- a/lua/ogpt/common/preview_window.lua
+++ b/lua/ogpt/common/preview_window.lua
@@ -1,5 +1,6 @@
 local Popup = require("nui.popup")
 local Config = require("ogpt.config")
+local event = require("nui.utils.autocmd").event
 
 local PreviewWindow = Popup:extend("PreviewWindow")
 
@@ -9,7 +10,9 @@ function PreviewWindow:init(options)
   PreviewWindow.super.init(self, options)
 end
 
-function PreviewWindow:mount()
+function PreviewWindow:mount(action)
+  action = action or {}
+
   PreviewWindow.super.mount(self)
 
   -- close
@@ -19,9 +22,22 @@ function PreviewWindow:mount()
   end
   for _, key in ipairs(keys) do
     self:map("n", key, function()
+      action.stop = true
       self:unmount()
     end)
   end
+
+  -- unmount component when cursor leaves buffer
+  self:on(event.BufLeave, function()
+    action.stop = true
+    self:unmount()
+  end)
+
+  -- dynamically resize
+  -- https://github.com/MunifTanjim/nui.nvim/blob/main/lua/nui/popup/README.md#popupupdate_layout
+  self:on(event.CursorMoved, function()
+    action:update_popup_size(self)
+  end)
 end
 
 return PreviewWindow

--- a/lua/ogpt/config.lua
+++ b/lua/ogpt/config.lua
@@ -154,7 +154,7 @@ function M.defaults()
       },
       buf_options = {
         modifiable = false,
-        readonly = true,
+        readonly = false,
         filetype = "markdown",
       },
       win_options = {

--- a/lua/ogpt/flows/actions/chat/init.lua
+++ b/lua/ogpt/flows/actions/chat/init.lua
@@ -39,6 +39,7 @@ function ChatAction:init(opts)
   self.variables = opts.variables or {}
   self.strategy = opts.strategy or STRATEGY_APPEND
   self.ui = opts.ui or {}
+  self.main_winid = vim.api.nvim_get_current_win()
 end
 
 function ChatAction:render_template()
@@ -90,13 +91,175 @@ function ChatAction:run()
         edit_code = false,
       })
     else
-      self:set_loading(true)
-      local params = self:get_params()
-      Api.chat_completions(params, function(answer, usage)
-        self:on_result(answer, usage)
-      end, nil, self.opts)
+      self:use_strategy()
+
+      -- params.stream = true
+      -- Api.chat_completions(
+      --   params,
+      --   Utils.partial(Utils.add_partial_completion, {
+      --     panel = PreviewWindow(ui_opts),
+      --     finalize_opts = {},
+      --     -- progress = show_process_flag,
+      --   }),
+      --   nil,
+      --   self.opts
+      -- )
     end
   end)
+end
+
+function ChatAction:update_popup_size(popup)
+  local lines = vim.api.nvim_buf_get_lines(popup.bufnr, 0, -1, false)
+  local ui_opts = self:calculate_size({
+    lines = lines,
+  })
+  popup:update_layout(ui_opts)
+end
+
+function ChatAction:calculate_size(opts)
+  opts = opts or {}
+  -- compute size
+  -- the width is calculated based on the maximum number of lines and the height is calculated based on the width
+  -- local cur_win = vim.api.nvim_get_current_win()
+  local cur_win = self.main_winid
+  local max_h = math.ceil(vim.api.nvim_win_get_height(cur_win) * 0.75)
+  local max_w = math.ceil(vim.api.nvim_win_get_width(cur_win) * 0.75)
+  local ui_w = 0
+  local len = 0
+  local ncount = 0
+  local lines = opts.lines or Utils.split_string_by_line(opts.text or "")
+  local _, start_row, start_col, end_row, end_col = self:get_visual_selection()
+
+  for _, v in ipairs(lines) do
+    local l = string.len(v)
+    if v == "" then
+      ncount = ncount + 1
+    end
+    ui_w = math.max(l, ui_w)
+    len = len + l
+  end
+  ui_w = math.min(ui_w, max_w)
+  ui_w = math.max(ui_w, 10)
+  local ui_h = math.ceil(len / ui_w) + ncount
+  ui_h = math.min(ui_h, max_h)
+  ui_h = math.max(ui_h, 1)
+
+  -- use opts
+  ui_w = opts.ui_w or ui_w
+  ui_h = opts.ui_h or ui_h
+
+  -- build ui opts
+  local ui_opts = vim.tbl_deep_extend("keep", {
+    size = {
+      width = ui_w,
+      height = ui_h,
+    },
+    border = {
+      style = "rounded",
+      text = {
+        top = " " .. (self.opts.title or self.opts.args) .. " ",
+        top_align = "left",
+      },
+    },
+    relative = {
+      type = "buf",
+      position = {
+        row = start_row,
+        col = start_col,
+      },
+    },
+    buf_options = {
+      readonly = false,
+    },
+  }, self.ui)
+  return ui_opts
+end
+
+function ChatAction:get_popup(opts)
+  local bufnr = self:get_bufnr()
+  local lines = Utils.split_string_by_line(opts.answer or "")
+  local _, start_row, start_col, end_row, end_col = self:get_visual_selection()
+
+  local ui_opts = self:calculate_size(opts)
+  local PreviewWindow = require("ogpt.common.preview_window")
+  local popup = PreviewWindow(ui_opts)
+  vim.api.nvim_buf_set_lines(popup.bufnr, 0, 1, false, lines)
+
+  local _replace = function(replace)
+    replace = replace or false
+    if replace then
+      vim.api.nvim_buf_set_text(bufnr, start_row - 1, start_col - 1, end_row - 1, end_col, lines)
+    else
+      table.insert(lines, 1, "")
+      table.insert(lines, "")
+      vim.api.nvim_buf_set_text(bufnr, end_row - 1, start_col - 1, end_row - 1, start_col - 1, lines)
+    end
+
+    if vim.fn.mode() == "i" then
+      vim.api.nvim_command("stopinsert")
+    end
+    vim.cmd("q")
+  end
+
+  -- accept output and replace
+  popup:map("n", "r", function()
+    _replace(true)
+  end)
+
+  -- accept output and append
+  popup:map("n", "a", function()
+    _replace(false)
+  end)
+
+  -- yank output and close
+  popup:map("n", "y", function()
+    vim.fn.setreg(Config.options.yank_register, lines)
+
+    if vim.fn.mode() == "i" then
+      vim.api.nvim_command("stopinsert")
+    end
+    vim.cmd("q")
+  end)
+
+  return popup
+end
+
+function ChatAction:use_strategy()
+  self:set_loading(true)
+  self.stop = false
+  local params = self:get_params()
+
+  if self.strategy == STRATEGY_DISPLAY then
+    local popup = self:get_popup({
+      -- ui_w = 80,
+      -- ui_h = 3,
+    })
+    popup:mount(self)
+
+    params.stream = true
+    Api.chat_completions(
+      params,
+      Utils.partial(Utils.add_partial_completion, {
+        panel = popup,
+        -- finalize_opts = opts,
+        progress = function(flag)
+          self:set_loading(flag)
+        end,
+      }),
+      function()
+        if self.stop then
+          self.stop = false
+          return true
+        else
+          return false
+        end
+      end
+    )
+  else
+    Api.chat_completions(params, function(answer, usage)
+      self:on_result(answer, usage)
+    end)
+  end
 end
 
 function ChatAction:on_result(answer, usage)
@@ -113,91 +276,9 @@ function ChatAction:on_result(answer, usage)
     local _, start_row, start_col, end_row, end_col = self:get_visual_selection()
 
     if self.strategy == STRATEGY_DISPLAY then
-      local PreviewWindow = require("ogpt.common.preview_window")
-      -- compute size
-      -- the width is calculated based on the maximum number of lines and the height is calculated based on the width
-      local cur_win = vim.api.nvim_get_current_win()
-      local max_h = math.ceil(vim.api.nvim_win_get_height(cur_win) * 0.75)
-      local max_w = math.ceil(vim.api.nvim_win_get_width(cur_win) * 0.75)
-      local ui_w = 0
-      local len = 0
-      local ncount = 0
-      for _, v in ipairs(lines) do
-        local l = string.len(v)
-        if v == "" then
-          ncount = ncount + 1
-        end
-        ui_w = math.max(l, ui_w)
-        len = len + l
-      end
-      ui_w = math.min(ui_w, max_w)
-      ui_w = math.max(ui_w, 10)
-      local ui_h = math.ceil(len / ui_w) + ncount
-      ui_h = math.min(ui_h, max_h)
-      ui_h = math.max(ui_h, 1)
-
-      -- build ui opts
-      local ui_opts = vim.tbl_deep_extend("keep", {
-        size = {
-          width = ui_w,
-          height = ui_h,
-        },
-        border = {
-          style = "rounded",
-          text = {
-            top = " " .. (self.opts.title or self.opts.args) .. " ",
-            top_align = "left",
-          },
-        },
-        relative = {
-          type = "buf",
-          position = {
-            row = start_row,
-            col = start_col,
-          },
-        },
-      }, self.ui)
-
-      local popup = PreviewWindow(ui_opts)
-      vim.api.nvim_buf_set_lines(popup.bufnr, 0, 1, false, lines)
-
-      local _replace = function(replace)
-        replace = replace or false
-        if replace then
-          vim.api.nvim_buf_set_text(bufnr, start_row - 1, start_col - 1, end_row - 1, end_col, lines)
-        else
-          table.insert(lines, 1, "")
-          table.insert(lines, "")
-          vim.api.nvim_buf_set_text(bufnr, end_row - 1, start_col - 1, end_row - 1, start_col - 1, lines)
-        end
-
-        if vim.fn.mode() == "i" then
-          vim.api.nvim_command("stopinsert")
-        end
-        vim.cmd("q")
-      end
-
-      -- accept output and replace
-      popup:map("n", "r", function()
-        _replace(true)
-      end)
-
-      -- accept output and append
-      popup:map("n", "a", function()
-        _replace(false)
-      end)
-
-      -- yank output and close
-      popup:map("n", "y", function()
-        vim.fn.setreg(Config.options.yank_register, lines)
-
-        if vim.fn.mode() == "i" then
-          vim.api.nvim_command("stopinsert")
-        end
-        vim.cmd("q")
-      end)
-
-      popup:mount()
+      -- moved out
+      -- local popup = self:get_popup(answer)
+      -- popup:mount()
     elseif self.strategy == STRATEGY_EDIT then
       Edits.edit_with_instructions(lines, bufnr, { self:get_visual_selection() }, {
         instruction = self.template,

--- a/lua/ogpt/flows/chat/base.lua
+++ b/lua/ogpt/flows/chat/base.lua
@@ -220,7 +220,7 @@ function Chat:addAnswerPartial(text, state, ctx)
     start_line = prev.end_line + (prev.type == ANSWER and 2 or 1)
   end
 
-  if state == "END" then
+  if state == "END" and text ~= "" then
     local usage = {}
     local idx = self.session:add_item({
       type = ANSWER,
@@ -562,8 +562,8 @@ function Chat:toMessages()
     end
     table.insert(messages, { role = role, content = msg.text })
   end
-  -- return self:toOllama(messages)
-  return messages[#messages].content
+  -- return messages[#messages].content
+  return messages
 end
 
 function Chat:toOllama(messages)
@@ -805,8 +805,9 @@ function Chat:open()
         self:showProgess()
         local params = vim.tbl_extend("keep", {
           stream = true,
-          context = self.session:previous_context(),
-          prompt = self.messages[#self.messages].text,
+          -- context = self.session:previous_context(),
+          -- prompt = self.messages[#self.messages].text,
+          messages = self:toMessages(),
           system = self.system_message,
         }, Parameters.params)
         Api.chat_completions(params, function(answer, state, ctx)

--- a/lua/ogpt/utils.lua
+++ b/lua/ogpt/utils.lua
@@ -311,7 +311,9 @@ local function _finalize_output(response, panel, opts)
   end
   local output_txt_nlfixed = M.replace_newlines_at_end(output_txt, nlcount)
   local output = M.split_string_by_line(output_txt_nlfixed)
-  vim.api.nvim_buf_set_lines(panel.bufnr, 0, -1, false, output)
+  if panel.bufnr then
+    vim.api.nvim_buf_set_lines(panel.bufnr, 0, -1, false, output)
+  end
 end
 
 function M.add_partial_completion(opts, text, state)
@@ -340,13 +342,15 @@ function M.add_partial_completion(opts, text, state)
     local buffer = panel.bufnr
     local win = panel.winid
 
-    for i, line in ipairs(lines) do
-      local currentLine = vim.api.nvim_buf_get_lines(buffer, -2, -1, false)[1]
-      vim.api.nvim_buf_set_lines(buffer, -2, -1, false, { currentLine .. line })
+    if buffer then
+      for i, line in ipairs(lines) do
+        local currentLine = vim.api.nvim_buf_get_lines(buffer, -2, -1, false)[1]
+        vim.api.nvim_buf_set_lines(buffer, -2, -1, false, { currentLine .. line })
 
-      local last_line_num = vim.api.nvim_buf_line_count(buffer)
-      if i == length and i > 1 then
-        vim.api.nvim_buf_set_lines(buffer, -1, -1, false, { "" })
+        local last_line_num = vim.api.nvim_buf_line_count(buffer)
+        if i == length and i > 1 then
+          vim.api.nvim_buf_set_lines(buffer, -1, -1, false, { "" })
+        end
       end
     end
   end

--- a/lua/ogpt/utils.lua
+++ b/lua/ogpt/utils.lua
@@ -187,12 +187,13 @@ end
 function M._conform_to_ollama_api(params)
   local ollama_parameters = {
     "model",
-    "prompt",
+    -- "prompt",
+    "messages",
     "format",
     "options",
     "system",
     "template",
-    "context",
+    -- "context",
     "stream",
     "raw",
   }
@@ -202,9 +203,13 @@ function M._conform_to_ollama_api(params)
   local param_options = {}
 
   for key, value in pairs(params) do
-    if not vim.tbl_contains(ollama_parameters, key) and vim.tbl_contains(M.ollama_options, key) then
-      param_options[key] = value
-      params[key] = nil
+    if not vim.tbl_contains(ollama_parameters, key) then
+      if vim.tbl_contains(M.ollama_options, key) then
+        param_options[key] = value
+        params[key] = nil
+      else
+        params[key] = nil
+      end
     end
   end
   local _options = vim.tbl_extend("keep", param_options, params.options or {})
@@ -216,21 +221,21 @@ end
 
 function M.conform_to_ollama(params)
   if params.messages then
-    local messages = params.messages
-    params.messages = nil
-    params.system = params.system or ""
-    params.prompt = params.prompt or ""
-    for _, message in ipairs(messages) do
-      if message.role == "system" then
-        params.system = params.system .. "\n" .. message.content .. "\n"
-      end
-    end
-
-    for _, message in ipairs(messages) do
-      if message.role == "user" then
-        params.prompt = params.prompt .. "\n" .. message.content .. "\n"
-      end
-    end
+    --   local messages = params.messages
+    --   params.messages = nil
+    --   params.system = params.system or ""
+    --   params.prompt = params.prompt or ""
+    --   for _, message in ipairs(messages) do
+    --     if message.role == "system" then
+    --       params.system = params.system .. "\n" .. message.content .. "\n"
+    --     end
+    --   end
+    --
+    --   for _, message in ipairs(messages) do
+    --     if message.role == "user" then
+    --       params.prompt = params.prompt .. "\n" .. message.content .. "\n"
+    --     end
+    --   end
   end
 
   return M._conform_to_ollama_api(params)


### PR DESCRIPTION
+ Updated to new Ollama release API calls to use /api/chat 
+ general clean up
+ able to stream outputs to actions, and chats. Useful to see the generated text and allow the user to make decision on the spot before a full completion happens.
