### PR TITLE
Fix example Lazy.nvim config and change setting window to parameter panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ https://github.com/huynle/ogpt.nvim/blob/main/lua/ogpt/config.lua#L18-L28
 ### Interactive Popup for 'display' strategy
 https://github.com/huynle/ogpt.nvim/blob/main/lua/ogpt/config.lua#L174-L181
 
-When the setting window is opened (with `<C-o>`), settings can be modified by
+When the parameter panels is opened (with `<C-o>`), settings can be modified by
 pressing `Enter` on the related config. Settings are saved across sessions.
 
 ### Example `lazy.nvim` Configuration

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ return {
     },
 
     opts = {
-      default_provider = "ollama"
+      default_provider = "ollama",
       -- default edgy flag
       -- set this to true if you prefer to use edgy.nvim (https://github.com/folke/edgy.nvim) instead of floating windows
       edgy = false, 
@@ -493,7 +493,7 @@ return {
         ollama= {
           api_host = os.getenv("OLLAMA_API_HOST"),
           -- default model
-          model = "mistral:7b"
+          model = "mistral:7b",
           -- model definitions
           models = {
             -- alias to actual model name, helpful to define same model name across multiple providers
@@ -758,6 +758,8 @@ return {
             },
           },
         },
+      },
+    },
     dependencies = {
       "MunifTanjim/nui.nvim",
       "nvim-lua/plenary.nvim",


### PR DESCRIPTION
- Add missing commas and brackets
- Move `dependencies` outside `opts`
- The window that pops up when pressed <C-o> is called parameter panels in
the rest of the document other than one place where it is called setting
window. Change from setting window to parameter panels to use consistent
naming conventions.