### PR TITLE
fix: Fix wrong descriptions and revise README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Features
 - **Multiple Providers**: OGPT.nvim can take multiple providers. Ollama, OpenAI, textgenui, Gemini, Anthropic, more if there are pull requests
 - **Mix-match Provider**: default provider is used, but you can mix and match different provider AND specific model to different actions, at any point in your run or configurations.
-- **Interactive Q&A**: Engage in interactive question-and-answer sessions with the powerful gpt model (OGPT) using an intuitive interface.
+- **Interactive Q&A**: Engage in interactive question-and-answer sessions with LLMs using an intuitive interface.
 - **Persona-based Conversations**: Explore various perspectives and have conversations with different personas by selecting prompts from Awesome ChatGPT Prompts.
 - **Customizable Actions**: Execute a range of actions utilizing the gpt model, such as grammar
   correction, translation, keyword generation, docstring creation, test addition, code
@@ -56,14 +56,13 @@ https://github.com/huynle/ogpt.nvim/blob/main/lua/ogpt/config.lua
 
 ### Ollama Setup
 
-`OGPT` is a Neovim plugin that allows you to effortlessly utilize the Ollama OGPT API,
-empowering you to generate natural language responses from Ollama's OGPT directly within the editor in response to your inquiries.
+`OGPT` is a Neovim plugin that allows you to effortlessly utilize the Ollama OGPT API, empowering you to generate natural language responses from Ollama directly within the editor in response to your prompts.
 
 - Make sure you have `curl` installed.
 - Have a local instance of Ollama running.
 
 Custom Ollama API host with the configuration option `api_host_cmd` or
-environment variable called `$OLLAMA_API_HOST`. It's useful if you run Ollama remotely 
+environment variable called `$OLLAMA_API_HOST`. It's useful if you run Ollama remotely.
 
 ### Gemini, TextGenUI, OpenAI, Anthropic Setup
 * not much here, you just have to get your API keys and provide that in your configuration. If your
@@ -73,8 +72,7 @@ keys
 ### Edgy.nvim setup
 ![edgy-example](assets/images/edgy-example.png.png)
 
-I prefer `edgy.nvim` over the floating windows. It allow for much better interaction. Here is an
-example of an 'edgy' configuration.
+`edgy.nvim` plugin offers a side window (positioned to the right by default) that provides a parallel working space where you can work on your project while interacting with OGPT. Here is an example of an 'edgy' configuration.
 
 ```lua
 {
@@ -167,7 +165,7 @@ example of an 'edgy' configuration.
           size = { height = 6 },
         },
         {
-          title = "OGPT Sesssions",
+          title = "OGPT Sessions",
           ft = "ogpt-sessions",
           size = { height = 6 },
           wo = {
@@ -222,58 +220,191 @@ example of an 'edgy' configuration.
 
 Plugin exposes following commands:
 
-#### `OGPT`
-`OGPT` command which opens interactive window using the  model in the `config.api_params`
-(also known as `OGPT`)
+### `OGPT`
+`OGPT` command opens an interactive window to communicate with LLM backends. The interactive window consists of four panes:
+* OGPT Chat: Input text area to write prompts.
+* OGPT: Output text area printing responses from LLM.
+* OGPT Parameters: (Toggled by \<Ctrl-o\>,) Parameter panel to display and modify LLM paramters.
+* OGPT Sessions: (Toggled by \<Ctrl-o\>,) Sessions panel to display chat sessions.
 
-#### `OGPTActAs`
+#### Useful shortcuts
+<table>
+    <thead>
+        <tr>
+            <th>Area</th>
+            <th>Default shortcuts</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td rowspan=6>Common</td>
+            <td>Ctrl-o</td>
+            <td>Toggle parameter panel (OGPT Parameters) and sessions panel (OGPT Sessions).</td>
+        </tr>
+        <tr>
+            <td>Ctrl-n</td>
+            <td>Create a new session.</td>
+        </tr>
+        <tr>
+            <td>Ctrl-c</td>
+            <td>Close OGPT.
+        </tr>
+        <tr>
+            <td>Ctrl-i</td>
+            <td>Copy code in LLM's latest response in OGPT output text area.
+        </tr>
+        <tr>
+            <td>Ctrl-x</td>
+            <td>Stop generating response.</td>
+        </tr>
+        <tr>
+            <td>Tab</td>
+            <td>Cycle through panes.</td>
+        </tr>
+        <tr>
+            <td rowspan=4>OGPT</td>
+            <td>K</td>
+            <td>Previous response.</td>
+        </tr>
+        <tr>
+            <td>J</td>
+            <td>Next response.</td>
+        </tr>
+        <tr>
+            <td>Ctrl-u</td>
+            <td>Scroll up.</td>
+        </tr>
+        <tr>
+            <td>Ctrl-d</td>
+            <td>Scroll down.</td>
+        </tr>
+        <tr>
+            <td rowspan=5>OGPT Chat</td>
+            <td>Enter<br>(normal mode)</td>
+            <td>Send prompt to LLM.</td>
+        </tr>
+        <tr>
+          <td>Alt-Enter<br>(input mode)</td>
+          <td>Send prompt to LLM.</td>
+        </tr>
+        <tr>
+          <td>Ctrl-y</td>
+          <td>Copy the latest response from LLM in OGPT output text area.</td>
+        </tr>
+        <tr>
+          <td>Ctrl-r</td>
+          <td>Toggle role (assistant or user).</td>
+        </tr>
+        <tr>
+          <td>Ctrl-s</td>
+          <td>Toggle system message.</td>
+        </tr>
+        <tr>
+          <td rowspan=1>OGPT Parameters</td>
+          <td>Enter</td>
+          <td>Change parameter.</td>
+        </tr>
+        <tr>
+            <td rowspan=3>OGPT Sessions</td>
+            <td>Enter</td>
+            <td>Switch session.</td>
+        </tr>
+        <tr>
+            <td>d</td>
+            <td>Delete session.</td>
+        </tr>
+        <tr>
+            <td>r</td>
+            <td>Rename session. Note that an active session cannot be removed.</td>
+        </tr>
+    </tbody>
+</table>
+
+<!-- Someone please fix the ugly HTML table to Markdown table -->
+<!-- Area | Default shortcuts | Description -->
+<!-- ---- | ---- | ---- -->
+<!-- Common | Ctrl-o | Toggle parameter panel (OGPT Parameters) and sessions panel (OGPT Sessions). -->
+<!--      ^ | Ctrl-n | Create a new session. -->
+<!--      ^ |      q | Close OGPT. -->
+<!--      ^ | Ctrl-c | Close OGPT. -->
+<!--      ^ | Ctrl-i | Copy code in LLM's latest response in OGPT output text area. -->
+<!--      ^ | Ctrl-c | Close OGPT. -->
+<!--      ^ | Ctrl-x | Stop generating response. -->
+<!--      ^ |    Tab | Cycle through panes. -->
+<!-- OGPT |      K | Previous response. -->
+<!--    ^ |      J | Next response. -->
+<!--    ^ | Ctrl-u | Scroll up. -->
+<!--    ^ | Ctrl-d | Scroll down. -->
+<!-- OGPT Chat |  Enter | Send prompt to LLM. -->
+<!--         ^ | Alt-Enter (input mode inside OGPT Chat) | Send prompt to LLM. -->
+<!--         ^ | Ctrl-y | Copy the latest response from LLM in OGPT output text area. -->
+<!--         ^ | Ctrl-r | Toggle role (assistant or user). -->
+<!--         ^ | Ctrl-s | Toggle system message. -->
+<!-- OGPT Parameters | Enter | Change parameter. -->
+<!-- OGPT Sessions | Enter | Switch session. -->
+<!--             ^ |     d | Delete session. -->
+<!--             ^ |     r | Rename session. Note that an active session cannot be removed. -->
+
+Shortcuts for OGPT interactive window can be modified at `opts.chat.keymaps`.
+
+### `OGPTActAs`
 `OGPTActAs` command which opens a prompt selection from [Awesome OGPT Prompts](https://github.com/f/awesome-chatgpt-prompts) to be used with the `mistral:7b` model.
 
-#### `OGPTRun edit_with_instructions`
-`OGPTRun edit_with_instructions` command which opens
-interactive window to edit selected text or whole window using the `deepseek-coder:6.7b` model, you
-can change in this in your config options. This model defined in `config.<provider>.api_params`.
+### `OGPTRun [action_name]`
 
-Use `<c-p>` (default keymap, can be customized)  to open and close the parameter panels. Note
-this screenshot is using `edgy.nvim`
+`OGPTRun [action_name]` runs LLM with predefined action named `[action_name]`. There are [default actions](https://github.com/huynle/ogpt.nvim/?tab=readme-ov-file#default-actions) provided by OGPT, and [custom actions](https://github.com/huynle/ogpt.nvim/?tab=readme-ov-file#custom-actions) defined by users.
+
+An action requires parameters to configure its behavior. Default model parameters are defined in `actions.<action_name>` in [config.lua](./lua/ogpt/config.lua), and custom model parameters are defined either in a custom OGPT configuration file or in a separate actions configuration file such as [`actions.json`](./lua/ogpt/actions.json).
+
+Some of the action parameters include:
+* `type`: The type of OGPT interface. Currently, there are three types of OGPT interface:
+  * `popup`: Light-weight popup window
+  * `edit`: OGPT window
+  * `completions`: Does not open a window, completes directly on the editing window
+* `strategy`: Determines the way OGPT interface behaves. There are specific `strategy`s you can use for each `type`:
+  * `type = "popup"`: display, replace, append, prepend, quick_fix
+  * `type = "completions"`: display, replace, append, prepend
+  * `type = "edits"`: edit, edit_code
+* `system`: System prompt
+* `params`: Model parameters. Default model parameters are defined in `opts.providers.<provider_name>.api_params`. You can customize model parameters in `opts.actions.<action_name>.params` and override default model parameters.
+  * `model`: LLM model to use for the action
+  * `stop`: Condition for LLM to stop generating response. For example, a useful stop condition for `codellama` is "\`\`\`". See "optimize_code" action in [Example `lazy.nvim` Configuration](https://github.com/huynle/ogpt.nvim/?tab=readme-ov-file#example-lazynvim-configuration).
+  * `temperature`: Variability of LLM's response
+  * `frequency_penalty`: Somebody explain please
+  * `max_tokens`: Maximum number of tokens
+  * `top_p`: Somebody explain please
+* `template`: Prompt template. Template defines a general instruction that LLM must follow. Template can include template argument in form of `{{{<argument_name>}}}`, where `<argument_name>` is a template argument defined in `args` . Other than the arguments defined in `args`, you can include the following arguments:
+  * `{{{input}}}`: The selected text in visual mode.
+  * `{{{filetype}}}`: The type of file you are interacting with.
+  * Is there any other useful template arguments I'm missing?
+* `args`: Template argument. Template arguments define the arguments that replace the arguments with the same name in `template`. Some common template arguments include:
+  * `instruction`: Custom instruction for LLM to follow. It tends to be more specific and structured than the general instruction that goes into `template`.
+  * `lang`: Language. Often used for language related actions, such as translation or grammar check.
+
+
+#### Default actions
+
+Default actions are defined in `actions.<action_name>` in [config.lua](./lua/ogpt/config.lua).
+
+##### Example: `OGPTRun edit_with_instructions`
+`OGPTRun edit_with_instructions` opens interactive window to edit selected text or whole window using the model defined in `config.<provider_name>.api_params`.
+
+By default, `OGPTRun edit_with_instructions`'s interface type is `edit`, which opens up an interactive window to the right. In the window, you can use `<c-o>` (default keymap, can be customized)  to open and close the parameter panels. Note this screenshot is using `edgy.nvim`
 
 ![edit_with_instruction_no_params](assets/images/edit_with_instruction_no_param_panel.png)
 
 ![edit_with_instructions_with_params](assets/images/edit_with_instruction_with_params_panel.png)
 
-#### `OGPTRun`
+#### Custom actions
 
-All commands will be using the model defined in `config.api_params` unless, overridden by the
-specific action.
+You can customize OGPT actions by defining them in a custom OGPT configuration files, or in a separate action file. The default model configurations in [config.lua](./lua/ogpt/config.lua) can be good references when making your own [custom actions](https://github.com/huynle/ogpt.nvim/?tab=readme-ov-file#custom-actions).
 
-##### Using Actions.json
-`OGPTRun [action]` command which runs specific actions -- see [`actions.json`](./lua/ogpt/flows/actions/actions.json) file for a detailed list. Available actions are:
+##### A custom OGPT configuration file (preferred)
 
-It is possible to define custom actions using a JSON file. Please see the example at [`actions.json`](./lua/ogpt/flows/actions/) for reference. The path to custom actions can be configured (see `actions_paths` field in the config example above).
+You can configure actions in your own OGPT configuration file (typically in a Lua file like `ogpt.lua` if using Neovim). In a custom OGPT configuration file, you must define actions in `actions.<action_name>` like the way default actions are defined in [config.lua](./lua/ogpt/config.lua).
 
-An example of custom action may look like this: (`#` marks comments)
-```python
-{
-  "action_name": {
-    "type": "popup", # "popup" or "edit"
-    "template": "A template using possible variable: {{{filetype}}} (neovim filetype), {{{input}}} (the selected text) an {{{argument}}} (provided on the command line)",
-    "strategy": "replace", # or "display" or "append" or "edit"
-    "params": { # parameters according to the official Ollama API
-      "model": "mistral:7b", # or any other model supported by `"type"` in the Ollama API, use the playground for reference
-      "stop": [
-        "```" # a string used to stop the model
-      ]
-    }
-    "args": {
-      "argument": "some value" -- or function
-    }
-  }
-}
-```
-
-##### Using Configuration Options (preferred)
 ```lua
-
 --- config options lua
 opts = {
   ...
@@ -304,15 +435,36 @@ opts = {
   ...
   }
 }
-
 ```
 
-The `edit` type consists in showing the output side by side with the input and
-available for further editing requests
+The `edit` type consists in showing the output side by side with the input and available for further editing prompts.
 
-The `display` strategy shows the output in a float window. 
-`append` and `replace` modify the text directly in the buffer with "a" or "r"
+The `display` strategy shows the output in a float window. `append` and `replace` modify the text directly in the buffer with "a" or "r"
 
+##### Using Actions.json
+
+It is possible to define custom actions using a JSON file. Please see the example at [`actions.json`](./lua/ogpt/actions.json) for reference.
+
+An example of custom action may look like the following: (`#` marks comments)
+```json
+{
+  "action_name": {
+    "type": "popup", # "popup" or "edit"
+    "template": "A template using possible variable: {{{filetype}}} (neovim filetype), {{{input}}} (the selected text) an {{{argument}}} (provided on the command line)",
+    "strategy": "replace", # or "display" or "append" or "edit"
+    "params": { # parameters according to the official Ollama API
+      "model": "mistral:7b", # or any other model supported by `"type"` in the Ollama API, use the playground for reference
+      "stop": [
+        "```" # a string used to stop the model
+      ]
+    }
+    "args": {
+      "argument": "some value" -- or function
+    }
+  }
+}
+```
+If you want to use other action files, you must append the paths to those files to `defaults.actions_paths` in [config.lua](./lua/ogpt/config.lua).
 
 #### Run With Options with Vim Commands
 On the fly, you can execute a command line to call OGPT. An example to replace
@@ -442,7 +594,7 @@ return {
       {
         "<leader>]c",
         "<cmd>OGPTRun edit_code_with_instructions<CR>",
-        "Edit with instruction",
+        "Edit code with instruction",
         mode = { "n", "v" },
       },
       {
@@ -488,7 +640,7 @@ return {
       default_provider = "ollama",
       -- default edgy flag
       -- set this to true if you prefer to use edgy.nvim (https://github.com/folke/edgy.nvim) instead of floating windows
-      edgy = false, 
+      edgy = false,
       providers = {
         ollama= {
           api_host = os.getenv("OLLAMA_API_HOST"),
@@ -892,7 +1044,7 @@ opts = {
       size = { height = 6 },
     },
     {
-      title = "OGPT Sesssions",
+      title = "OGPT Sessions",
       ft = "ogpt-sessions",
       size = { height = 6 },
       wo = {

--- a/lua/ogpt/config.lua
+++ b/lua/ogpt/config.lua
@@ -377,7 +377,7 @@ function M.defaults()
     },
 
     actions_paths = {
-      -- default action that comes with ogpt/lua/flow/actions
+      -- default action that comes with lua/ogpt/actions.json
       debug.getinfo(1, "S").source:sub(2):match("(.*/)") .. "actions.json",
     },
     show_quickfixes_cmd = "Trouble quickfix",


### PR DESCRIPTION
Fix wrong descriptions in README. Further polish language to eliminate ambiguity, and improve overall readability.
- Fix wrong descriptions
  - Change path to `actions.json` from `./lua/ogpt/flows/actions/actions.json` to `./lua/ogpt/actions.json`
  - Change default keymap to open parameter panel from `<c-p>` to `<c-o>`
- Polish contents in `OGPT` section
  - Explain each panes in OGPT interactive window
  - Add helpful commands used in OGPT interactive window. Commands are currently organized using HTML table, which is difficult to parse in source mode. TODO: Change to a neater and tidier markdown-format table.
- Restructure and add more contents to `OGPTRun [action_name]` section
  - Divide section by default and custom actions
  - Add descriptions on action parameters
    - Explain the fixed relationship between "type" and "strategy"
    - Explain "template" and "args" in detail with focus on the relationship between the two
- Improve word consistencies
  - Use "prompt" instead of request, inquery, query. Use "request" only for API request or pull requests.