### PR TITLE
Fix window filetype override options

### DIFF
--- a/lua/ogpt/common/popup.lua
+++ b/lua/ogpt/common/popup.lua
@@ -9,8 +9,6 @@ function Popup:init(options, edgy)
   if options.edgy and options.border or edgy then
     self.edgy = true
     options.border = nil
-  else
-    options.buf_options.filetype = nil
   end
   Popup.super.init(self, options)
 end

--- a/lua/ogpt/common/popup.lua
+++ b/lua/ogpt/common/popup.lua
@@ -20,7 +20,7 @@ function Popup:mount()
   -- syntax and filetype don't always get set in the correct order.
   -- This for syntax to be the last thing to be set.
   if self._.buf_options["syntax"] then
-    vim.api.nvim_buf_set_option(self.bufnr, "syntax", self._.buf_options["syntax"])
+    vim.api.nvim_set_option_value("syntax", self._.buf_options["syntax"], { buf = self.bufnr })
   end
 end
 

--- a/lua/ogpt/common/popup.lua
+++ b/lua/ogpt/common/popup.lua
@@ -19,8 +19,11 @@ function Popup:mount()
   Popup.super.mount(self)
   -- syntax and filetype don't always get set in the correct order.
   -- This for syntax to be the last thing to be set.
+  if self._.buf_options["filetype"] then
+    vim.api.nvim_set_option_value("filetype", self._.buf_options["filetype"], { buf = self.bufnr })
+  end
   if self._.buf_options["syntax"] then
-    vim.api.nvim_buf_set_option(self.bufnr, "syntax", self._.buf_options["syntax"])
+    vim.api.nvim_set_option_value("syntax", self._.buf_options["syntax"], { buf = self.bufnr })
   end
 end
 

--- a/lua/ogpt/common/ui/window.lua
+++ b/lua/ogpt/common/ui/window.lua
@@ -82,15 +82,12 @@ function SimpleView:mount(name, opts)
   end
   self.bufnr = vim.api.nvim_get_current_buf()
   self.winid = vim.api.nvim_get_current_win()
-
-  vim.api.nvim_buf_set_option(self.bufnr, "filetype", name)
-
-  -- vim.api.nvim_exec_autocmds("Syntax", { buffer = self.bufnr, Syntax = opts.buf.filetype })
+  vim.api.nvim_set_option_value("filetype", name, { buf = self.bufnr })
 
   -- Set the buffer type to "nofile" to prevent it from being saved.
   -- vim.api.nvim_buf_set_option(self.bufnr, "buftype", "nofile")
-  for opt, val in pairs(opts.buf) do
-    vim.api.nvim_buf_set_option(self.bufnr, opt, val)
+  for opt, _ in pairs(opts.buf) do
+    vim.api.nvim_set_option_value(opt, name, { buf = self.bufnr })
   end
 
   -- -- Disable swapfile for the buffer.

--- a/lua/ogpt/flows/actions/edits/init.lua
+++ b/lua/ogpt/flows/actions/edits/init.lua
@@ -31,7 +31,7 @@ function EditAction:init(name, opts)
   self.output_panel = nil
   self.parameters_panel = nil
   self.timer = nil
-  self.filetype = vim.api.nvim_buf_get_option(self:get_bufnr(), "filetype")
+  self.filetype = vim.api.nvim_get_option_value("filetype", { buf = self:get_bufnr() })
 
   self.ui = opts.ui or {}
 
@@ -295,15 +295,31 @@ function EditAction:edit_with_instructions(output_lines, selection, opts, ...)
           self.system_role_panel:mount()
 
           vim.api.nvim_set_current_win(self.parameters_panel.winid)
-          vim.api.nvim_buf_set_option(self.parameters_panel.bufnr, "modifiable", false)
-          vim.api.nvim_win_set_option(self.parameters_panel.winid, "cursorline", true)
+          vim.api.nvim_set_option_value(
+            "modifiable",
+            false,
+            { scope = "local", win = self.parameters_panel.winid, buf = self.parameters_panel.bufnr }
+          )
+          vim.api.nvim_set_option_value(
+            "cursorline",
+            true,
+            { scope = "local", win = self.parameters_panel.winid, buf = self.parameters_panel.bufnr }
+          )
         end
         parameters_open = not parameters_open
         -- set input and output settings
         --  TODO
         for _, window in ipairs({ self.selection_panel, self.output_panel }) do
-          vim.api.nvim_buf_set_option(window.bufnr, "syntax", self.filetype)
-          vim.api.nvim_win_set_option(window.winid, "number", true)
+          vim.api.nvim_set_option_value("filetype", self.filetype, {
+            scope = "local",
+            win = window.winid,
+            buf = window.bufnr,
+          })
+          vim.api.nvim_set_option_value("number", true, {
+            scope = "local",
+            win = window.winid,
+            buf = window.bufnr,
+          })
         end
       end, {})
     end
@@ -408,8 +424,16 @@ function EditAction:edit_with_instructions(output_lines, selection, opts, ...)
 
   -- set input and output settings
   for _, window in ipairs({ self.selection_panel, self.output_panel }) do
-    vim.api.nvim_buf_set_option(window.bufnr, "syntax", "markdown")
-    vim.api.nvim_win_set_option(window.winid, "number", true)
+    vim.api.nvim_set_option_value("filetype", "markdown", {
+      scope = "local",
+      win = window.winid,
+      buf = window.bufnr,
+    })
+    vim.api.nvim_set_option_value("number", true, {
+      scope = "local",
+      win = window.winid,
+      buf = window.bufnr,
+    })
   end
   -- end)
 end

--- a/lua/ogpt/flows/actions/edits/init.lua
+++ b/lua/ogpt/flows/actions/edits/init.lua
@@ -31,7 +31,7 @@ function EditAction:init(name, opts)
   self.output_panel = nil
   self.parameters_panel = nil
   self.timer = nil
-  self.filetype = vim.api.nvim_buf_get_option(self:get_bufnr(), "filetype")
+  self.filetype = vim.api.nvim_get_option_value("filetype", { buf = self:get_bufnr() })
 
   self.ui = opts.ui or {}
 
@@ -295,15 +295,31 @@ function EditAction:edit_with_instructions(output_lines, selection, opts, ...)
           self.system_role_panel:mount()
 
           vim.api.nvim_set_current_win(self.parameters_panel.winid)
-          vim.api.nvim_buf_set_option(self.parameters_panel.bufnr, "modifiable", false)
-          vim.api.nvim_win_set_option(self.parameters_panel.winid, "cursorline", true)
+          vim.api.nvim_set_option_value(
+            "modifiable",
+            false,
+            { scope = "local", win = self.parameters_panel.winid, buf = self.parameters_panel.bufnr }
+          )
+          vim.api.nvim_set_option_value(
+            "cursorline",
+            true,
+            { scope = "local", win = self.parameters_panel.winid, buf = self.parameters_panel.bufnr }
+          )
         end
         parameters_open = not parameters_open
         -- set input and output settings
         --  TODO
         for _, window in ipairs({ self.selection_panel, self.output_panel }) do
-          vim.api.nvim_buf_set_option(window.bufnr, "syntax", self.filetype)
-          vim.api.nvim_win_set_option(window.winid, "number", true)
+          vim.api.nvim_set_option_value("filetype", self.filetype, {
+            scope = "local",
+            win = window.winid,
+            buf = window.bufnr,
+          })
+          vim.api.nvim_set_option_value("number", true, {
+            scope = "local",
+            win = window.winid,
+            buf = window.bufnr,
+          })
         end
       end, {})
     end
@@ -408,8 +424,16 @@ function EditAction:edit_with_instructions(output_lines, selection, opts, ...)
 
   -- set input and output settings
   for _, window in ipairs({ self.selection_panel, self.output_panel }) do
-    vim.api.nvim_buf_set_option(window.bufnr, "syntax", "markdown")
-    vim.api.nvim_win_set_option(window.winid, "number", true)
+    vim.api.nvim_set_option_value("filetype", self.filetype, {
+      scope = "local",
+      win = window.winid,
+      buf = window.bufnr,
+    })
+    vim.api.nvim_set_option_value("number", true, {
+      scope = "local",
+      win = window.winid,
+      buf = window.bufnr,
+    })
   end
   -- end)
 end


### PR DESCRIPTION
These changes will allow the `buf_options.filetype` properties in user configs to apply to a given window. Also, resolves a few deprecated functions.